### PR TITLE
include fixes accounting for recent discord change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ log = "0.4.17"
 
 [dependencies.songbird]
 version = "0.3.0"
-features = ["driver", "yt-dlp"]
+features = ["driver", "yt-dlp", "builtin-queue"]
+git = "https://github.com/Erk-/songbird/"
+branch = "do-not-fail-if-new-opcode"
 
 [dependencies.pyo3]
 version = "0.16.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,8 @@ pyo3-log = "0.6.0"
 log = "0.4.17"
 
 [dependencies.songbird]
-version = "0.3.0"
+version = "0.3.2"
 features = ["driver", "yt-dlp", "builtin-queue"]
-git = "https://github.com/Erk-/songbird/"
-branch = "do-not-fail-if-new-opcode"
 
 [dependencies.pyo3]
 version = "0.16.4"


### PR DESCRIPTION
Updated the cargo.toml to use the new 0.3.2 version of songbird for the build process. 